### PR TITLE
form: allow to bypass "client-side" validation

### DIFF
--- a/core/src/main/java/com/cosium/hal_mock_mvc/Form.java
+++ b/core/src/main/java/com/cosium/hal_mock_mvc/Form.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -29,73 +30,88 @@ public class Form {
     this.template = requireNonNull(template);
   }
 
-  public Form withString(String propertyName, String value) throws Exception {
+  public Form withString(String propertyName, String value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             String.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withBoolean(String propertyName, Boolean value) throws Exception {
+  public Form withBoolean(
+      String propertyName, Boolean value, PropertyValidator... ignoredValidators) throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Boolean.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withInteger(String propertyName, Integer value) throws Exception {
+  public Form withInteger(
+      String propertyName, Integer value, PropertyValidator... ignoredValidators) throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Integer.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withLong(String propertyName, Long value) throws Exception {
+  public Form withLong(String propertyName, Long value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Long.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withDouble(String propertyName, Double value) throws Exception {
+  public Form withDouble(String propertyName, Double value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Double.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withStrings(String propertyName, List<String> value) throws Exception {
+  public Form withStrings(
+      String propertyName, List<String> value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property = new FormProperty<>(String.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withBooleans(String propertyName, List<Boolean> value) throws Exception {
+  public Form withBooleans(
+      String propertyName, List<Boolean> value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property = new FormProperty<>(Boolean.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withIntegers(String propertyName, List<Integer> value) throws Exception {
+  public Form withIntegers(
+      String propertyName, List<Integer> value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property = new FormProperty<>(Integer.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withLongs(String propertyName, List<Long> value) throws Exception {
+  public Form withLongs(
+      String propertyName, List<Long> value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property = new FormProperty<>(Long.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
-  public Form withDoubles(String propertyName, List<Double> value) throws Exception {
+  public Form withDoubles(
+      String propertyName, List<Double> value, PropertyValidator... ignoredValidators)
+      throws Exception {
     FormProperty<?> property = new FormProperty<>(Double.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property));
+    propertyByName.put(property.name(), validate(property, ignoredValidators));
     return this;
   }
 
@@ -167,9 +183,20 @@ public class Form {
             .formatted(String.join(",", expectedBadRequestReasons), status));
   }
 
-  private ValidatedFormProperty<?> validate(FormProperty<?> property) throws Exception {
-    TemplatePropertyRepresentation representation = requireTemplate(property);
-    if (representation.readOnly()) {
+  private ValidatedFormProperty<?> validate(
+      FormProperty<?> property, PropertyValidator... ignoredValidators) throws Exception {
+    Set<PropertyValidator> ignored =
+        Optional.ofNullable(ignoredValidators).map(Set::of).orElse(Set.of());
+    TemplatePropertyRepresentation representation =
+        template.representation().propertyByName().get(property.name());
+    if (representation == null) {
+      if (!ignored.contains(PropertyValidator.EXISTING)) {
+        throw new AssertionError("No property '%s' found.".formatted(property.name()));
+      }
+      return ValidatedFormProperty.markAsValid(property);
+    }
+
+    if (representation.readOnly() && !ignored.contains(PropertyValidator.READ_ONLY)) {
       throw new AssertionError(
           "Cannot set value for read-only property '%s'".formatted(property.name()));
     }
@@ -181,12 +208,5 @@ public class Form {
       throw new AssertionError(firstValidationError.reason());
     }
     return validatedFormProperty;
-  }
-
-  private TemplatePropertyRepresentation requireTemplate(FormProperty<?> property) {
-    TemplateRepresentation templateRepresentation = template.representation();
-    return Optional.ofNullable(templateRepresentation.propertyByName().get(property.name()))
-        .orElseThrow(
-            () -> new AssertionError("No property '%s' found.".formatted(property.name())));
   }
 }

--- a/core/src/main/java/com/cosium/hal_mock_mvc/Form.java
+++ b/core/src/main/java/com/cosium/hal_mock_mvc/Form.java
@@ -30,88 +30,93 @@ public class Form {
     this.template = requireNonNull(template);
   }
 
-  public Form withString(String propertyName, String value, PropertyValidator... ignoredValidators)
+  public Form withString(
+      String propertyName, String value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             String.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withBoolean(
-      String propertyName, Boolean value, PropertyValidator... ignoredValidators) throws Exception {
+      String propertyName, Boolean value, PropertyValidationOption... validationOptions)
+      throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Boolean.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withInteger(
-      String propertyName, Integer value, PropertyValidator... ignoredValidators) throws Exception {
+      String propertyName, Integer value, PropertyValidationOption... validationOptions)
+      throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Integer.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
-  public Form withLong(String propertyName, Long value, PropertyValidator... ignoredValidators)
+  public Form withLong(
+      String propertyName, Long value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Long.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
-  public Form withDouble(String propertyName, Double value, PropertyValidator... ignoredValidators)
+  public Form withDouble(
+      String propertyName, Double value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property =
         new FormProperty<>(
             Double.class, propertyName, Optional.ofNullable(value).stream().toList(), false);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withStrings(
-      String propertyName, List<String> value, PropertyValidator... ignoredValidators)
+      String propertyName, List<String> value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property = new FormProperty<>(String.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withBooleans(
-      String propertyName, List<Boolean> value, PropertyValidator... ignoredValidators)
+      String propertyName, List<Boolean> value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property = new FormProperty<>(Boolean.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withIntegers(
-      String propertyName, List<Integer> value, PropertyValidator... ignoredValidators)
+      String propertyName, List<Integer> value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property = new FormProperty<>(Integer.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withLongs(
-      String propertyName, List<Long> value, PropertyValidator... ignoredValidators)
+      String propertyName, List<Long> value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property = new FormProperty<>(Long.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
   public Form withDoubles(
-      String propertyName, List<Double> value, PropertyValidator... ignoredValidators)
+      String propertyName, List<Double> value, PropertyValidationOption... validationOptions)
       throws Exception {
     FormProperty<?> property = new FormProperty<>(Double.class, propertyName, value, true);
-    propertyByName.put(property.name(), validate(property, ignoredValidators));
+    propertyByName.put(property.name(), validate(property, validationOptions));
     return this;
   }
 
@@ -184,19 +189,22 @@ public class Form {
   }
 
   private ValidatedFormProperty<?> validate(
-      FormProperty<?> property, PropertyValidator... ignoredValidators) throws Exception {
-    Set<PropertyValidator> ignored =
-        Optional.ofNullable(ignoredValidators).map(Set::of).orElse(Set.of());
+      FormProperty<?> property, PropertyValidationOption... validationOptions) throws Exception {
+    Set<PropertyValidationOption> validationOptionSet =
+        Optional.ofNullable(validationOptions).map(Set::of).orElse(Set.of());
     TemplatePropertyRepresentation representation =
         template.representation().propertyByName().get(property.name());
     if (representation == null) {
-      if (!ignored.contains(PropertyValidator.EXISTING)) {
+      if (!validationOptionSet.contains(
+          PropertyValidationOption.Immediate.DO_NOT_FAIL_IF_NOT_DECLARED)) {
         throw new AssertionError("No property '%s' found.".formatted(property.name()));
       }
       return ValidatedFormProperty.markAsValid(property);
     }
 
-    if (representation.readOnly() && !ignored.contains(PropertyValidator.READ_ONLY)) {
+    if (representation.readOnly()
+        && !validationOptionSet.contains(
+            PropertyValidationOption.Immediate.DO_NOT_FAIL_IF_DECLARED_READ_ONLY)) {
       throw new AssertionError(
           "Cannot set value for read-only property '%s'".formatted(property.name()));
     }

--- a/core/src/main/java/com/cosium/hal_mock_mvc/PropertyValidationOption.java
+++ b/core/src/main/java/com/cosium/hal_mock_mvc/PropertyValidationOption.java
@@ -1,0 +1,14 @@
+package com.cosium.hal_mock_mvc;
+
+/**
+ * @author Sébastien Le Ray
+ * @author Réda Housni Alaoui
+ */
+public sealed interface PropertyValidationOption permits PropertyValidationOption.Immediate {
+  enum Immediate implements PropertyValidationOption {
+    /** Do not fail if writing to a property not declared by the template */
+    DO_NOT_FAIL_IF_NOT_DECLARED,
+    /** Do not fail if writing to a property declared as read-only by the template */
+    DO_NOT_FAIL_IF_DECLARED_READ_ONLY
+  }
+}

--- a/core/src/main/java/com/cosium/hal_mock_mvc/PropertyValidator.java
+++ b/core/src/main/java/com/cosium/hal_mock_mvc/PropertyValidator.java
@@ -1,0 +1,8 @@
+package com.cosium.hal_mock_mvc;
+
+public enum PropertyValidator {
+  /** Property exists in template definition */
+  EXISTING,
+  /** Property is read-only in template definition */
+  READ_ONLY
+}

--- a/core/src/main/java/com/cosium/hal_mock_mvc/PropertyValidator.java
+++ b/core/src/main/java/com/cosium/hal_mock_mvc/PropertyValidator.java
@@ -1,8 +1,0 @@
-package com.cosium.hal_mock_mvc;
-
-public enum PropertyValidator {
-  /** Property exists in template definition */
-  EXISTING,
-  /** Property is read-only in template definition */
-  READ_ONLY
-}

--- a/core/src/test/java/com/cosium/hal_mock_mvc/FormTest.java
+++ b/core/src/test/java/com/cosium/hal_mock_mvc/FormTest.java
@@ -1793,7 +1793,10 @@ class FormTest {
             .byKey("default")
             .createForm();
 
-    assertThatCode(() -> form.withString("foo", "foo", PropertyValidator.EXISTING))
+    assertThatCode(
+            () ->
+                form.withString(
+                    "foo", "foo", PropertyValidationOption.Immediate.DO_NOT_FAIL_IF_NOT_DECLARED))
         .doesNotThrowAnyException();
   }
 
@@ -1831,7 +1834,12 @@ class FormTest {
             .templates()
             .byKey("default")
             .createForm();
-    assertThatCode(() -> form.withString("foo", "foo", PropertyValidator.READ_ONLY))
+    assertThatCode(
+            () ->
+                form.withString(
+                    "foo",
+                    "foo",
+                    PropertyValidationOption.Immediate.DO_NOT_FAIL_IF_DECLARED_READ_ONLY))
         .doesNotThrowAnyException();
   }
 

--- a/core/src/test/java/com/cosium/hal_mock_mvc/FormTest.java
+++ b/core/src/test/java/com/cosium/hal_mock_mvc/FormTest.java
@@ -1,6 +1,7 @@
 package com.cosium.hal_mock_mvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
@@ -325,7 +326,7 @@ class FormTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"month", "week", "number"})
-  @DisplayName("User cannot pass a number value when the type is only compatible with number")
+  @DisplayName("User can pass a number value when the type is only compatible with number")
   void test7(String halFormType) throws Exception {
     myController.getResponseToSend =
         JSON.std
@@ -1759,6 +1760,79 @@ class FormTest {
 
     assertThat(JsonPath.parse(myController.receivedPutBody).read("$.foo", String.class))
         .isEqualTo("baz");
+  }
+
+  @Test
+  @DisplayName("User can force pass an unknown property")
+  void test38() throws Exception {
+    myController.getResponseToSend =
+        JSON.std
+            .composeString()
+            .startObject()
+            .startObjectField("_links")
+            .startObjectField("self")
+            .put("href", "http://localhost/form-test:put")
+            .end()
+            .end()
+            .startObjectField("_templates")
+            .startObjectField("default")
+            .put("method", "PUT")
+            .startArrayField("properties")
+            .end()
+            .end()
+            .end()
+            .end()
+            .finish();
+
+    Form form =
+        HalMockMvc.builder(mockMvc)
+            .baseUri(linkTo(methodOn(MyController.class).get()).toUri())
+            .build()
+            .follow()
+            .templates()
+            .byKey("default")
+            .createForm();
+
+    assertThatCode(() -> form.withString("foo", "foo", PropertyValidator.EXISTING))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("User can force a readonly property")
+  void test39() throws Exception {
+    myController.getResponseToSend =
+        JSON.std
+            .composeString()
+            .startObject()
+            .startObjectField("_links")
+            .startObjectField("self")
+            .put("href", "http://localhost/form-test:put")
+            .end()
+            .end()
+            .startObjectField("_templates")
+            .startObjectField("default")
+            .put("method", "PUT")
+            .startArrayField("properties")
+            .startObject()
+            .put("name", "foo")
+            .put("readOnly", true)
+            .end()
+            .end()
+            .end()
+            .end()
+            .end()
+            .finish();
+
+    Form form =
+        HalMockMvc.builder(mockMvc)
+            .baseUri(linkTo(methodOn(MyController.class).get()).toUri())
+            .build()
+            .follow()
+            .templates()
+            .byKey("default")
+            .createForm();
+    assertThatCode(() -> form.withString("foo", "foo", PropertyValidator.READ_ONLY))
+        .doesNotThrowAnyException();
   }
 
   @Controller


### PR DESCRIPTION
Add additional arguments allowing to selectively bypass checks performed on field addition to verify that they're taken into account server side